### PR TITLE
Add Spanish translation and update ChangeUser plugin and component

### DIFF
--- a/resources/lang/en/change-user.php
+++ b/resources/lang/en/change-user.php
@@ -2,5 +2,7 @@
 
 // translations for Rmsramos/ChangeUser
 return [
-    //
+    'Change user' => 'Change user',
+    'Email' => 'Email',
+    'Password' => 'Password',
 ];

--- a/resources/lang/es/change-user.php
+++ b/resources/lang/es/change-user.php
@@ -1,0 +1,8 @@
+<?php
+
+// translations for Rmsramos/ChangeUser
+return [
+    'Change user' => 'Cambiar de usuario',
+    'Email' => 'Correo electrónico',
+    'Password' => 'Contraseña',
+];

--- a/src/ChangeUserPlugin.php
+++ b/src/ChangeUserPlugin.php
@@ -18,6 +18,8 @@ class ChangeUserPlugin implements Plugin
 
     public bool | Closure | null $showButton = null;
 
+    public string | Closure | null $setIcon = null;
+
     public function getId(): string
     {
         return 'change-user';
@@ -78,5 +80,17 @@ class ChangeUserPlugin implements Plugin
         $this->showButton = $showButton;
 
         return $this;
+    }
+
+    public function setIcon(string | Closure $setIcon = 'heroicon-o-arrow-path'): static
+    {
+        $this->setIcon = $setIcon;
+
+        return $this;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->evaluate($this->setIcon) ?? 'heroicon-o-arrow-path';
     }
 }

--- a/src/Livewire/ChangeUserButtonComponent.php
+++ b/src/Livewire/ChangeUserButtonComponent.php
@@ -2,38 +2,48 @@
 
 namespace Rmsramos\ChangeUser\Livewire;
 
-use Filament\Actions\Action;
-use Filament\Actions\Concerns\InteractsWithActions;
-use Filament\Actions\Contracts\HasActions;
-use Filament\Facades\Filament;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
-use Filament\Http\Responses\Auth\Contracts\LoginResponse;
-use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\ValidationException;
 use Livewire\Component;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Rmsramos\ChangeUser\ChangeUserPlugin;
+use Filament\Actions\Contracts\HasActions;
+use Illuminate\Validation\ValidationException;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 
 class ChangeUserButtonComponent extends Component implements HasActions, HasForms
 {
     use InteractsWithActions;
     use InteractsWithForms;
 
+    public string $icon = '';
+
+    public function mount()
+    {
+        $this->icon = ChangeUserPlugin::get()->getIcon();
+    }
+
     public function loginAction()
     {
         return Action::make('login')
-            ->icon('heroicon-o-arrow-path')
+            ->icon($this->icon)
             ->iconButton()
-            ->modalHeading('Change user')
+            ->modalHeading(__('Change user'))
             ->modalWidth('lg')
             ->form([
                 TextInput::make('email')
+                    ->label(__('Email'))
                     ->email()
                     ->required()
                     ->autofocus()
                     ->extraInputAttributes(['tabindex' => 1]),
                 TextInput::make('password')
+                    ->label(__('Password'))
                     ->password()
                     ->required()
                     ->extraInputAttributes(['tabindex' => 2])
@@ -41,7 +51,7 @@ class ChangeUserButtonComponent extends Component implements HasActions, HasForm
             ])
             ->action(function (array $data): ?LoginResponse {
 
-                if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data))) {
+                if (!Filament::auth()->attempt($this->getCredentialsFromFormData($data))) {
 
                     Notification::make()
                         ->warning()
@@ -55,7 +65,7 @@ class ChangeUserButtonComponent extends Component implements HasActions, HasForm
 
                 if (
                     ($user instanceof FilamentUser) &&
-                    (! $user->canAccessPanel(Filament::getCurrentPanel()))
+                    (!$user->canAccessPanel(Filament::getCurrentPanel()))
                 ) {
                     Filament::auth()->logout();
 
@@ -67,7 +77,6 @@ class ChangeUserButtonComponent extends Component implements HasActions, HasForm
                 ]);
 
                 return app(LoginResponse::class);
-
             });
     }
 


### PR DESCRIPTION
Modified English language file. Added Spanish language file. Updated ChangeUserPlugin and ChangeUserButtonComponent to handle default icon.


##  Icon configuration in ChangeUserPlugin

With this modification the `ChangeUserPlugin` plugin allows you to set a custom icon to be used in the `ChangeUserButtonComponent` component. By default, the icon is `heroicon-o-arrow-path`. However, you can customize this icon using the `setIcon` method.

###  Example of use

To set a custom icon, use the `setIcon` method. In the following example, the icon is set to `heroicon-o-finger-print`:

```php
ChangeUserPlugin::make()
    ->setIcon(fn () => 'heroicon-o-finger-print');      

